### PR TITLE
Fix compile issue with memset

### DIFF
--- a/termdbg/widgets/RegistersView.hpp
+++ b/termdbg/widgets/RegistersView.hpp
@@ -38,7 +38,7 @@ public:
 	RegistersView(cpu& cpu)
 		: _header(make_child<FoldableWidgetHeader>("Registers"))
 		, _cpu(cpu) {
-		memset(_previous_values, 0, 16);
+		memset(_previous_values, 0, sizeof(_previous_values));
 		regs_text.set_alignment(cppurses::Alignment::Left);
 		regs_text.clear();
 	}


### PR DESCRIPTION
With gcc > 6.5 I have the following error :

```
micromachine/termdbg/widgets/RegistersView.hpp:41:33: error: ‘memset’
used with length equal to number of elements without multiplication
by element size [-Werror=memset-elt-size]
   41 |   memset(_previous_values, 0, 16);             
```

  