### PR TITLE
Remove compiler invokation template

### DIFF
--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -12,7 +12,6 @@ else()
 endif()
 
 function(add_micromachine_executable)
-	set_property(TARGET ${ARGV0} PROPERTY C_STANDARD 11)
 	set(LINKER_SCRIPT ${CMAKE_SOURCE_DIR}/link.ld)
 	set_target_properties(${ARGV0} PROPERTIES LINK_FLAGS "-T ${LINKER_SCRIPT}")
 	set_target_properties(${ARGV0} PROPERTIES LINK_DEPENDS ${LINKER_SCRIPT})

--- a/sdk/micromachine.toolchain
+++ b/sdk/micromachine.toolchain
@@ -16,21 +16,17 @@ set(CMAKE_ASM_COMPILER "${TARGET_PREFIX}as")
 
 UNSET(CMAKE_C_FLAGS CACHE)
 UNSET(CMAKE_CXX_FLAGS CACHE)
-set(CMAKE_C_FLAGS "-c -g -std=c99 -ffreestanding -mcpu=cortex-m0 -mthumb -mfloat-abi=soft -nostdlib -march=armv6s-m"
-    CACHE STRING "" FORCE)
+set(COMMON_CFLAGS "-ffreestanding -mcpu=cortex-m0 -mthumb -mfloat-abi=soft -nostdlib -march=armv6s-m")
+set(CMAKE_C_FLAGS "${COMMON_CFLAGS} -std=c11")
 # note that to avoid undefined reference to `__cxa_guard_acquire' the threadsafe static initialization of c++11 is
 # disabled
 # note that to avoid undefined reference to  `__dso_handle and `__aeabi_atexit the option -fno-use-cxa-atexit is added
-set(CMAKE_CXX_FLAGS "-g -std=c99 -ffreestanding -mcpu=cortex-m0 -mthumb -mfloat-abi=soft -nostdlib -fno-use-cxa-atexit -fno-threadsafe-statics -fno-exceptions -march=armv6s-m" CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS "${COMMON_CFLAGS} -fno-use-cxa-atexit -fno-threadsafe-statics -fno-exceptions -march=armv6s-m")
 
 set(CUSTOM_LD_FLAGS "-nostdlib -nodefaultlibs -nostartfiles")
 
 set(CMAKE_C_LINK_FLAGS "${CUSTOM_LD_FLAGS}")
 set(CMAKE_CXX_LINK_FLAGS "${CUSTOM_LD_FLAGS}")
-
-set(CMAKE_C_LINK_EXECUTABLE "${CMAKE_LINKER} <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> <LINK_LIBRARIES> -o <TARGET>")
-set(CMAKE_CXX_LINK_EXECUTABLE "${CMAKE_CXX_LINKER} <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> <LINK_LIBRARIES> -o <TARGET>")
-
 
 # where is the target environment
 SET(CMAKE_FIND_ROOT_PATH ${CMAKE_SOURCE_DIR})

--- a/sdk/system/CMakeLists.txt
+++ b/sdk/system/CMakeLists.txt
@@ -21,4 +21,3 @@ set(HEADERS
 	include/system.h
 )
 add_library(system STATIC  ${HEADERS} ${SRCS})
-target_compile_features(system PRIVATE c_std_11)

--- a/sdk/system/interrupt_handlers.c
+++ b/sdk/system/interrupt_handlers.c
@@ -24,7 +24,7 @@ void _isr_nmi(void) {
 INTERRUPT_DEFAULT_IMPL
 void _isr_hardfault(void) {
 	// peek the return addres from the stack into r0
-	register uint32_t stack asm("sp");
+	register uint32_t stack __asm__("sp");
 	printf("ISR HARDFAULT %08x\n", stack);
 	breakpoint(0);
 }


### PR DESCRIPTION
* Force c11 as standard
* Remove cache entry for CMAKE_CXX_FLAGS and CMAKE_C_FLAGS
* Remove compiler invokation template

fix #15 