### PR TITLE
update flag while reading a register from a valid address

### DIFF
--- a/micromachine/memory/memory.hpp
+++ b/micromachine/memory/memory.hpp
@@ -167,6 +167,7 @@ private:
 			if(address >= 0xE0000000) {
 				auto reg_it = _system_control_registers.find(address);
 				if(_system_control_registers.end() != reg_it) {
+					ok = true;
 					return reg_it->second.get();
 				}
 			}


### PR DESCRIPTION
Problem:
Reading a register (from the client code) return an old / unpredicted value.
```
uint32_t register_content = IO_REG;
printf("content: 0x%x\n", register_content);
```
Will print `content: 0xe000ef90` in this case, which is wrong.

Solution:
the `memory::read` should update `ok` flag when reading a valid address.